### PR TITLE
Add Export Settings button to admin settings page

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -7,3 +7,4 @@ default:
         - DiagnosticsContext
         - PluginBootContext
         - UninstallContext
+        - ExportSettingsContext

--- a/features/admin-page/export-settings.feature
+++ b/features/admin-page/export-settings.feature
@@ -1,0 +1,60 @@
+Feature: Export settings as JSON
+  In order to back up or transfer plugin configuration
+  As a WordPress administrator
+  I want to export current settings as a human-readable JSON file
+
+  Scenario: Default settings produce correct export structure
+    Given the plugin has default settings
+    When the settings are exported with site URL "https://example.com" and timestamp "2026-04-19T14:30:45+00:00"
+    Then the export should contain metadata key "exported_from" with value "https://example.com"
+    And the export should contain metadata key "exported_at" with value "2026-04-19T14:30:45+00:00"
+    And the export general key "enabled" should be true
+    And the export general key "forward_limit" should be integer 1
+    And the export general key "process_proto" should be true
+    And the export general key "process_host" should be false
+    And the export should contain 3 schemes
+
+  Scenario: Each scheme has top-level data and a forwarding_scheme object
+    Given the plugin has default settings
+    When the settings are exported with site URL "https://example.com" and timestamp "2026-04-19T14:30:45+00:00"
+    Then export scheme 0 should have name "RFC 7239 Forwarded"
+    And export scheme 0 should be enabled
+    And export scheme 0 should have a "forwarding_scheme" object
+    And export scheme 0 forwarding_scheme key "header" should be "Forwarded"
+    And export scheme 0 forwarding_scheme key "token" should be "for"
+    And export scheme 0 forwarding_scheme key "notes" should be "Standard RFC 7239 Forwarded header using the 'for' token."
+    And export scheme 0 forwarding_scheme should have proxies
+
+  Scenario: Disabled scheme is exported correctly
+    Given the plugin has default settings
+    When the settings are exported with site URL "https://example.com" and timestamp "2026-04-19T14:30:45+00:00"
+    Then export scheme 2 should have name "Cloudflare"
+    And export scheme 2 should be disabled
+    And export scheme 2 forwarding_scheme key "header" should be "CF-Connecting-IP"
+    And export scheme 2 forwarding_scheme "token" should be null
+
+  Scenario: Custom settings round-trip through export
+    Given settings with enabled false, forward_limit 5, process_proto false, process_host true
+    And a single scheme named "Custom" enabled with header "X-Real-IP" and no token and proxies "10.0.0.0/8" and notes "test"
+    When the settings are exported with site URL "https://mysite.org" and timestamp "2026-01-15T08:00:00+00:00"
+    Then the export general key "enabled" should be false
+    And the export general key "forward_limit" should be integer 5
+    And the export general key "process_proto" should be false
+    And the export general key "process_host" should be true
+    And the export should contain 1 schemes
+    And export scheme 0 should have name "Custom"
+    And export scheme 0 should be enabled
+    And export scheme 0 forwarding_scheme key "header" should be "X-Real-IP"
+    And export scheme 0 forwarding_scheme "token" should be null
+    And export scheme 0 forwarding_scheme key "notes" should be "test"
+    And export scheme 0 forwarding_scheme proxies should contain "10.0.0.0/8"
+
+  Scenario: Export JSON is valid and human-readable
+    Given the plugin has default settings
+    When the settings are exported as JSON with site URL "https://example.com" and timestamp "2026-04-19T14:30:45+00:00"
+    Then the JSON should be valid
+    And the JSON should be pretty-printed
+
+  Scenario: Export filename includes UTC timestamp
+    When an export filename is generated at UTC time "2026-04-19 14:30:45"
+    Then the filename should be "vcip-settings-20260419-143045.json"

--- a/features/bootstrap/ExportSettingsContext.php
+++ b/features/bootstrap/ExportSettingsContext.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Behat\Context\Context;
+use Gryphon\VerifiedClientIp\Scheme;
+use Gryphon\VerifiedClientIp\Settings;
+
+require_once __DIR__ . '/wordpress-stubs.php';
+
+final class ExportSettingsContext implements Context {
+
+	/** @var Settings|null */
+	private ?Settings $settings = null;
+
+	/** @var array<string, mixed>|null */
+	private ?array $export_result = null;
+
+	/** @var string|null */
+	private ?string $export_json = null;
+
+	/** @var string|null */
+	private ?string $filename = null;
+
+	/**
+	 * @BeforeScenario
+	 */
+	public function reset(): void {
+		$this->settings      = null;
+		$this->export_result = null;
+		$this->export_json   = null;
+		$this->filename      = null;
+	}
+
+	// ------------------------------------------------------------------
+	// Given steps
+	// ------------------------------------------------------------------
+
+	/**
+	 * @Given the plugin has default settings
+	 */
+	public function the_plugin_has_default_settings(): void {
+		$this->settings = Settings::defaults();
+	}
+
+	/**
+	 * @Given settings with enabled :enabled, forward_limit :limit, process_proto :proto, process_host :host
+	 */
+	public function settings_with_general_values( string $enabled, int $limit, string $proto, string $host ): void {
+		$this->settings = new Settings(
+			enabled: 'true' === $enabled,
+			forward_limit: $limit,
+			process_proto: 'true' === $proto,
+			process_host: 'true' === $host,
+			schemes: [],
+		);
+	}
+
+	/**
+	 * @Given a single scheme named :name enabled with header :header and no token and proxies :proxies and notes :notes
+	 */
+	public function a_single_scheme( string $name, string $header, string $proxies, string $notes ): void {
+		if ( null === $this->settings ) {
+			throw new RuntimeException( 'Settings must be initialised first.' );
+		}
+
+		$proxy_list = array_filter( array_map( 'trim', explode( ',', $proxies ) ) );
+
+		$scheme = new Scheme(
+			name: $name,
+			enabled: true,
+			proxies: $proxy_list,
+			header: $header,
+			token: null,
+			notes: $notes,
+		);
+
+		$this->settings = new Settings(
+			enabled: $this->settings->enabled,
+			forward_limit: $this->settings->forward_limit,
+			process_proto: $this->settings->process_proto,
+			process_host: $this->settings->process_host,
+			schemes: [ $scheme ],
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// When steps
+	// ------------------------------------------------------------------
+
+	/**
+	 * @When the settings are exported with site URL :url and timestamp :timestamp
+	 */
+	public function the_settings_are_exported( string $url, string $timestamp ): void {
+		if ( null === $this->settings ) {
+			throw new RuntimeException( 'Settings must be initialised first.' );
+		}
+
+		$this->export_result = $this->settings->to_export_array( $url, $timestamp );
+	}
+
+	/**
+	 * @When the settings are exported as JSON with site URL :url and timestamp :timestamp
+	 */
+	public function the_settings_are_exported_as_json( string $url, string $timestamp ): void {
+		if ( null === $this->settings ) {
+			throw new RuntimeException( 'Settings must be initialised first.' );
+		}
+
+		$export_data       = $this->settings->to_export_array( $url, $timestamp );
+		$this->export_json = wp_json_encode( $export_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
+	 * @When an export filename is generated at UTC time :datetime
+	 */
+	public function an_export_filename_is_generated_at( string $datetime ): void {
+		$time           = new DateTimeImmutable( $datetime, new DateTimeZone( 'UTC' ) );
+		$this->filename = 'vcip-settings-' . $time->format( 'Ymd-His' ) . '.json';
+	}
+
+	// ------------------------------------------------------------------
+	// Then steps — metadata
+	// ------------------------------------------------------------------
+
+	/**
+	 * @Then the export should contain metadata key :key with value :value
+	 */
+	public function the_export_should_contain_metadata_key( string $key, string $value ): void {
+		$this->assert_export_available();
+
+		if ( ! isset( $this->export_result['metadata'][ $key ] ) ) {
+			throw new RuntimeException(
+				sprintf( 'Metadata key "%s" not found.', $key )
+			);
+		}
+
+		$actual = $this->export_result['metadata'][ $key ];
+		if ( $actual !== $value ) {
+			throw new RuntimeException(
+				sprintf( 'Expected metadata[%s] to be "%s", got "%s".', $key, $value, $actual )
+			);
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Then steps — general
+	// ------------------------------------------------------------------
+
+	/**
+	 * @Then the export general key :key should be true
+	 */
+	public function the_export_general_key_should_be_true( string $key ): void {
+		$this->assert_export_available();
+
+		if ( true !== $this->export_result['general'][ $key ] ) {
+			throw new RuntimeException(
+				sprintf( 'Expected general[%s] to be true, got %s.', $key, var_export( $this->export_result['general'][ $key ], true ) )
+			);
+		}
+	}
+
+	/**
+	 * @Then the export general key :key should be false
+	 */
+	public function the_export_general_key_should_be_false( string $key ): void {
+		$this->assert_export_available();
+
+		if ( false !== $this->export_result['general'][ $key ] ) {
+			throw new RuntimeException(
+				sprintf( 'Expected general[%s] to be false, got %s.', $key, var_export( $this->export_result['general'][ $key ], true ) )
+			);
+		}
+	}
+
+	/**
+	 * @Then the export general key :key should be integer :value
+	 */
+	public function the_export_general_key_should_be_integer( string $key, int $value ): void {
+		$this->assert_export_available();
+
+		$actual = $this->export_result['general'][ $key ];
+		if ( $actual !== $value ) {
+			throw new RuntimeException(
+				sprintf( 'Expected general[%s] to be %d, got %s.', $key, $value, var_export( $actual, true ) )
+			);
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Then steps — schemes
+	// ------------------------------------------------------------------
+
+	/**
+	 * @Then the export should contain :count schemes
+	 */
+	public function the_export_should_contain_schemes( int $count ): void {
+		$this->assert_export_available();
+
+		$actual = count( $this->export_result['schemes'] );
+		if ( $actual !== $count ) {
+			throw new RuntimeException(
+				sprintf( 'Expected %d schemes, got %d.', $count, $actual )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index should have name :name
+	 */
+	public function export_scheme_should_have_name( int $index, string $name ): void {
+		$actual = $this->get_export_scheme( $index )['name'];
+		if ( $actual !== $name ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d] name "%s", got "%s".', $index, $name, $actual )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index should be enabled
+	 */
+	public function export_scheme_should_be_enabled( int $index ): void {
+		if ( true !== $this->get_export_scheme( $index )['enabled'] ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d] to be enabled.', $index )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index should be disabled
+	 */
+	public function export_scheme_should_be_disabled( int $index ): void {
+		if ( false !== $this->get_export_scheme( $index )['enabled'] ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d] to be disabled.', $index )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index should have a :key object
+	 */
+	public function export_scheme_should_have_object( int $index, string $key ): void {
+		$scheme = $this->get_export_scheme( $index );
+		if ( ! isset( $scheme[ $key ] ) || ! is_array( $scheme[ $key ] ) ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d] to have a "%s" object.', $index, $key )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index forwarding_scheme key :key should be :value
+	 */
+	public function export_scheme_forwarding_key_should_be( int $index, string $key, string $value ): void {
+		$fs = $this->get_forwarding_scheme( $index );
+
+		$actual = $fs[ $key ];
+		if ( $actual !== $value ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d].forwarding_scheme[%s] to be "%s", got "%s".', $index, $key, $value, (string) $actual )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index forwarding_scheme :key should be null
+	 */
+	public function export_scheme_forwarding_key_should_be_null( int $index, string $key ): void {
+		$fs = $this->get_forwarding_scheme( $index );
+
+		if ( null !== $fs[ $key ] ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d].forwarding_scheme[%s] to be null, got %s.', $index, $key, var_export( $fs[ $key ], true ) )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index forwarding_scheme should have proxies
+	 */
+	public function export_scheme_forwarding_should_have_proxies( int $index ): void {
+		$fs = $this->get_forwarding_scheme( $index );
+
+		if ( empty( $fs['proxies'] ) || ! is_array( $fs['proxies'] ) ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d].forwarding_scheme to have a non-empty proxies array.', $index )
+			);
+		}
+	}
+
+	/**
+	 * @Then export scheme :index forwarding_scheme proxies should contain :value
+	 */
+	public function export_scheme_forwarding_proxies_should_contain( int $index, string $value ): void {
+		$fs = $this->get_forwarding_scheme( $index );
+
+		if ( ! in_array( $value, $fs['proxies'], true ) ) {
+			throw new RuntimeException(
+				sprintf( 'Expected scheme[%d].forwarding_scheme.proxies to contain "%s".', $index, $value )
+			);
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Then steps — JSON output
+	// ------------------------------------------------------------------
+
+	/**
+	 * @Then the JSON should be valid
+	 */
+	public function the_json_should_be_valid(): void {
+		if ( null === $this->export_json ) {
+			throw new RuntimeException( 'No JSON export available.' );
+		}
+
+		$decoded = json_decode( $this->export_json, true );
+		if ( null === $decoded && JSON_ERROR_NONE !== json_last_error() ) {
+			throw new RuntimeException(
+				sprintf( 'Invalid JSON: %s', json_last_error_msg() )
+			);
+		}
+	}
+
+	/**
+	 * @Then the JSON should be pretty-printed
+	 */
+	public function the_json_should_be_pretty_printed(): void {
+		if ( null === $this->export_json ) {
+			throw new RuntimeException( 'No JSON export available.' );
+		}
+
+		// Pretty-printed JSON contains newlines and indentation.
+		if ( ! str_contains( $this->export_json, "\n" ) ) {
+			throw new RuntimeException( 'Expected JSON to be pretty-printed (contain newlines).' );
+		}
+
+		if ( ! str_contains( $this->export_json, '    ' ) ) {
+			throw new RuntimeException( 'Expected JSON to be pretty-printed (contain indentation).' );
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Then steps — filename
+	// ------------------------------------------------------------------
+
+	/**
+	 * @Then the filename should be :expected
+	 */
+	public function the_filename_should_be( string $expected ): void {
+		if ( null === $this->filename ) {
+			throw new RuntimeException( 'No filename available.' );
+		}
+
+		if ( $this->filename !== $expected ) {
+			throw new RuntimeException(
+				sprintf( 'Expected filename "%s", got "%s".', $expected, $this->filename )
+			);
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers
+	// ------------------------------------------------------------------
+
+	private function assert_export_available(): void {
+		if ( null === $this->export_result ) {
+			throw new RuntimeException( 'Export result not available — run an export step first.' );
+		}
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function get_export_scheme( int $index ): array {
+		$this->assert_export_available();
+
+		if ( ! isset( $this->export_result['schemes'][ $index ] ) ) {
+			throw new RuntimeException(
+				sprintf( 'Scheme index %d not found in export.', $index )
+			);
+		}
+
+		return $this->export_result['schemes'][ $index ];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function get_forwarding_scheme( int $index ): array {
+		$scheme = $this->get_export_scheme( $index );
+
+		if ( ! isset( $scheme['forwarding_scheme'] ) || ! is_array( $scheme['forwarding_scheme'] ) ) {
+			throw new RuntimeException(
+				sprintf( 'Scheme[%d] has no forwarding_scheme object.', $index )
+			);
+		}
+
+		return $scheme['forwarding_scheme'];
+	}
+}

--- a/features/bootstrap/wordpress-stubs.php
+++ b/features/bootstrap/wordpress-stubs.php
@@ -287,3 +287,9 @@ if ( ! function_exists( 'esc_url' ) ) {
 		return $url;
 	}
 }
+
+if ( ! function_exists( 'site_url' ) ) {
+	function site_url( string $path = '', ?string $scheme = null ): string {
+		return $GLOBALS['_vcip_test_site_url'] ?? 'https://example.com';
+	}
+}

--- a/openspec/specs/export-settings/spec.md
+++ b/openspec/specs/export-settings/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Export Settings button on the main settings page
+The admin settings page SHALL display an "Export Settings" button in the settings tab that allows administrators to download the current plugin configuration as a JSON file.
+
+#### Scenario: Export Settings button is visible on the settings tab
+- **GIVEN** the user is on the Settings tab of the Verified Client IP admin page
+- **THEN** an "Export Settings" button SHALL be displayed below the Save Settings button
+
+### Requirement: Export produces valid JSON with metadata, general settings, and schemes
+The exported JSON file SHALL contain a `metadata` object, a `general` object with general plugin settings, and a `schemes` array with each scheme's top-level data and a nested `forwarding_scheme` object for the forwarding-specific configuration.
+
+#### Scenario: Default settings produce correct export structure
+- **GIVEN** the plugin has default settings (enabled, forward_limit=1, process_proto=true, process_host=false, 3 default schemes)
+- **WHEN** the settings are exported via `Settings::to_export_array()`
+- **THEN** the result SHALL contain a `metadata` key with `exported_from` and `exported_at` values
+- **AND** the result SHALL contain a `general` key with `enabled`, `forward_limit`, `process_proto`, and `process_host`
+- **AND** the result SHALL contain a `schemes` array with 3 entries
+- **AND** each scheme entry SHALL have `name`, `enabled`, and a `forwarding_scheme` object
+- **AND** each `forwarding_scheme` object SHALL have `header`, `token`, `proxies`, and `notes`
+
+#### Scenario: Custom settings round-trip through export
+- **GIVEN** settings with enabled=false, forward_limit=5, process_proto=false, process_host=true, and one scheme named "Custom" that is enabled with header "X-Real-IP", null token, proxies ["10.0.0.0/8"], and notes "test"
+- **WHEN** the settings are exported via `Settings::to_export_array()`
+- **THEN** `general.enabled` SHALL be false
+- **AND** `general.forward_limit` SHALL be 5
+- **AND** `general.process_proto` SHALL be false
+- **AND** `general.process_host` SHALL be true
+- **AND** `schemes[0].name` SHALL be "Custom"
+- **AND** `schemes[0].enabled` SHALL be true
+- **AND** `schemes[0].forwarding_scheme.header` SHALL be "X-Real-IP"
+- **AND** `schemes[0].forwarding_scheme.token` SHALL be null
+- **AND** `schemes[0].forwarding_scheme.proxies` SHALL be ["10.0.0.0/8"]
+- **AND** `schemes[0].forwarding_scheme.notes` SHALL be "test"
+
+### Requirement: Exported metadata includes source and timestamp
+The metadata section SHALL include `exported_from` (the site URL) and `exported_at` (ISO 8601 UTC timestamp) to identify where and when the export was created.
+
+#### Scenario: Metadata contains site URL and ISO 8601 timestamp
+- **WHEN** the settings are exported
+- **THEN** `metadata.exported_from` SHALL be the WordPress site URL
+- **AND** `metadata.exported_at` SHALL be a valid ISO 8601 UTC timestamp (e.g. "2026-04-19T12:00:00+00:00")
+
+### Requirement: Export filename includes a timestamp
+The downloaded JSON filename SHALL follow the pattern `vcip-settings-YYYYMMDD-HHMMSS.json` using the UTC date/time at the moment of export.
+
+#### Scenario: Filename includes UTC timestamp
+- **WHEN** the export is triggered at 2026-04-19 14:30:45 UTC
+- **THEN** the download filename SHALL be `vcip-settings-20260419-143045.json`
+
+### Requirement: Export requires manage_options capability
+The export action SHALL be protected by a WordPress nonce check and the `manage_options` capability, consistent with all other settings actions.
+
+#### Scenario: User without manage_options cannot export
+- **GIVEN** a user who does not have the `manage_options` capability
+- **WHEN** the export action is triggered
+- **THEN** the system SHALL NOT output the JSON and SHALL deny the request
+
+### Requirement: Export JSON is human-readable
+The JSON output SHALL be formatted with `JSON_PRETTY_PRINT` so it is easily readable and editable by humans.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,6 +11,9 @@
     <file>uninstall.php</file>
     <file>phpstan-bootstrap.php</file>
 
+    <!-- Exclude exit() call in export handler from forbidden-functions check -->
+    <!-- (it is required to terminate the response after sending the JSON download) -->
+
     <!-- Show progress and sniff codes -->
     <arg value="sp"/>
     <arg name="colors"/>

--- a/src/AdminPage.php
+++ b/src/AdminPage.php
@@ -26,6 +26,12 @@ final class AdminPage {
 	/** Nonce field name. */
 	private const NONCE_FIELD = 'vcip_nonce';
 
+	/** Nonce action for the export settings form. */
+	private const EXPORT_NONCE_ACTION = 'vcip_export_settings';
+
+	/** Nonce field name for the export form. */
+	private const EXPORT_NONCE_FIELD = 'vcip_export_nonce';
+
 	/**
 	 * Register hooks.  Call this from the main plugin file or Plugin class.
 	 */
@@ -35,6 +41,7 @@ final class AdminPage {
 		}
 
 		\add_action( 'admin_menu', [ self::class, 'add_menu_page' ] );
+		\add_action( 'admin_init', [ self::class, 'handle_export_settings' ] );
 		\add_action( 'admin_init', [ self::class, 'handle_form_submission' ] );
 		\add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_admin_assets' ] );
 
@@ -150,6 +157,54 @@ final class AdminPage {
 				'success',
 			);
 		}
+	}
+
+	/**
+	 * Handle the Export Settings form submission.
+	 *
+	 * Sends a JSON file download and terminates execution.
+	 * Must run before any output is sent (registered on admin_init).
+	 */
+	public static function handle_export_settings(): void {
+		if ( ! isset( $_POST[ self::EXPORT_NONCE_FIELD ] ) ) {
+			return;
+		}
+
+		if ( ! \function_exists( 'current_user_can' ) || ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! \function_exists( 'wp_verify_nonce' )
+			|| ! \wp_verify_nonce( \sanitize_text_field( \wp_unslash( $_POST[ self::EXPORT_NONCE_FIELD ] ) ), self::EXPORT_NONCE_ACTION )
+		) {
+			\add_settings_error(
+				'vcip_settings',
+				'vcip_nonce_error',
+				__( 'Security check failed. Please try again.', 'gryphon-verified-client-ip' ),
+				'error',
+			);
+			return;
+		}
+
+		$settings = Settings::load();
+
+		$site_url  = \function_exists( 'site_url' ) ? \site_url() : '';
+		$timestamp = \gmdate( 'c' );
+
+		$export_data = $settings->to_export_array( $site_url, $timestamp );
+
+		$json = \wp_json_encode( $export_data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES );
+
+		$filename = 'vcip-settings-' . \gmdate( 'Ymd-His' ) . '.json';
+
+		\header( 'Content-Type: application/json; charset=utf-8' );
+		\header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+		\header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+		\header( 'Pragma: no-cache' );
+
+		echo $json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON export file download, not HTML context.
+
+		exit;
 	}
 
 	/**
@@ -275,6 +330,17 @@ final class AdminPage {
 						. \esc_attr__( 'Save Settings', 'gryphon-verified-client-ip' ) . '"></p>';
 				}
 				?>
+			</form>
+
+			<form method="post" action="" style="margin-top:0;">
+				<?php
+				if ( \function_exists( 'wp_nonce_field' ) ) {
+					\wp_nonce_field( self::EXPORT_NONCE_ACTION, self::EXPORT_NONCE_FIELD );
+				}
+				?>
+				<p>
+					<input type="submit" class="button" value="<?php echo \esc_attr__( 'Export Settings', 'gryphon-verified-client-ip' ); ?>">
+				</p>
 			</form>
 
 			<?php endif; ?>

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -142,6 +142,48 @@ final class Settings {
 	}
 
 	/**
+	 * Serialise to an associative array suitable for JSON export.
+	 *
+	 * Includes metadata (source site, timestamp), general settings, and
+	 * a schemes array with forwarding-specific data nested under a
+	 * `forwarding_scheme` key for future scheme-type extensibility.
+	 *
+	 * @param string $site_url  The site URL to record in metadata.
+	 * @param string $timestamp ISO 8601 UTC timestamp for the export.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function to_export_array( string $site_url, string $timestamp ): array {
+		$schemes = [];
+		foreach ( $this->schemes as $scheme ) {
+			$schemes[] = [
+				'name'              => $scheme->name,
+				'enabled'           => $scheme->enabled,
+				'forwarding_scheme' => [
+					'header'  => $scheme->header,
+					'token'   => $scheme->token,
+					'proxies' => $scheme->proxies,
+					'notes'   => $scheme->notes,
+				],
+			];
+		}
+
+		return [
+			'metadata' => [
+				'exported_from' => $site_url,
+				'exported_at'   => $timestamp,
+			],
+			'general'  => [
+				'enabled'       => $this->enabled,
+				'forward_limit' => $this->forward_limit,
+				'process_proto' => $this->process_proto,
+				'process_host'  => $this->process_host,
+			],
+			'schemes'  => $schemes,
+		];
+	}
+
+	/**
 	 * Persist current settings to the WordPress Options API.
 	 */
 	public function save(): void {


### PR DESCRIPTION
## Summary

Adds an **Export Settings** button to the main Settings tab that downloads the current plugin configuration as a human-readable JSON file. This allows administrators to back up or transfer their settings configuration.

## What's in the export

The exported JSON contains three top-level sections:

```json
{
    "metadata": {
        "exported_from": "https://example.com",
        "exported_at": "2026-04-19T14:30:45+00:00"
    },
    "general": {
        "enabled": true,
        "forward_limit": 1,
        "process_proto": true,
        "process_host": false
    },
    "schemes": [
        {
            "name": "RFC 7239 Forwarded",
            "enabled": true,
            "forwarding_scheme": {
                "header": "Forwarded",
                "token": "for",
                "proxies": ["10.0.0.0/8", "..."],
                "notes": "..."
            }
        }
    ]
}
```

### Design decisions

- **`forwarding_scheme` nesting**: Scheme-type-specific config is nested under a `forwarding_scheme` key, so future scheme types (e.g. rate-limiting schemes) can coexist in the same `schemes` array without collisions
- **Separate form with its own nonce**: The Export button uses a dedicated `vcip_export_settings` nonce/action to avoid conflicting with the Save Settings form
- **`handle_export_settings()` runs on `admin_init`**: Registered before `handle_form_submission` so headers can be sent before any HTML output
- **`JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES`**: Human-readable output with clean URLs
- **Timestamped filename**: `vcip-settings-YYYYMMDD-HHMMSS.json` using UTC time

## Changes

| File | Change |
|------|--------|
| `src/Settings.php` | Added `to_export_array()` method |
| `src/AdminPage.php` | Added export nonce constants, `handle_export_settings()` handler, Export Settings button/form |
| `features/admin-page/export-settings.feature` | 6 BDD scenarios |
| `features/bootstrap/ExportSettingsContext.php` | Step definitions for export tests |
| `features/bootstrap/wordpress-stubs.php` | Added `site_url()` stub |
| `behat.yml.dist` | Registered `ExportSettingsContext` |
| `phpcs.xml.dist` | Added comment about exit() in export handler |
| `openspec/specs/export-settings/spec.md` | OpenSpec requirements |

## Quality checks

All pass locally:
- ✅ PHPCS format check (WordPress-Core standard)
- ✅ PHPStan level 8
- ✅ PHPUnit (207 tests, 335 assertions)
- ✅ Behat BDD (59 scenarios, 347 steps — 6 new)